### PR TITLE
[week6] 탐욕법(Greedy)

### DIFF
--- a/42861. 섬 연결하기/solution.py
+++ b/42861. 섬 연결하기/solution.py
@@ -1,0 +1,21 @@
+def solution(n, costs):
+    answer = 0
+
+    # 비용 순 정렬
+    costs.sort(key=lambda x : x[2])
+
+    # 시작점 포함
+    linked = {costs[0][0]}
+    
+    while len(linked) != n:
+        for start, end, cost in costs:
+            # 이미 연결된 다리는 건너뜀
+            if start in linked and end in linked:
+                continue
+            # 적어도 하나만 연결된 경우 확장
+            if start in linked or end in linked:
+                linked.update([start, end])
+                answer += cost
+                break
+
+    return answer

--- a/42862. 체육복/solution.py
+++ b/42862. 체육복/solution.py
@@ -1,0 +1,11 @@
+def solution(n, lost, reserve):
+    students_with_extra = set(reserve) - set(lost)
+    students_who_lost = set(lost) - set(reserve)
+
+    for student in students_with_extra:
+        if student - 1 in students_who_lost:
+            students_who_lost.remove(student - 1)
+        elif student + 1 in students_who_lost:
+            students_who_lost.remove(student + 1)
+        
+    return n - len(students_who_lost)

--- a/42883. 큰 수 만들기/solution.py
+++ b/42883. 큰 수 만들기/solution.py
@@ -1,0 +1,31 @@
+def solution(number, k):
+    # digits = list(number)
+    # numbers = []
+    
+    # for comb in combinations(digits, len(number) - k):
+    #     numbers.append(int(''.join(comb)))
+       
+    # return str(max(numbers))
+
+    # count = 0
+    # while count != k:
+    #     for idx in range(len(digits) - 1):
+    #         if int(digits[idx]) < int(digits[idx + 1]):
+    #             digits.pop(idx)
+    #             count += 1
+    #             break
+    #         if idx == len(digits) - 2 and count == k - 1:
+    #             digits.pop(idx + 1)
+    
+    stack = []
+    for digit in number:
+        while k > 0 and stack and stack[-1] < digit:
+            stack.pop()
+            k -= 1
+        stack.append(digit)
+    
+    # 남은 k만큼 뒤에서 제거
+    if k > 0:
+        stack = stack[:-k]
+
+    return ''.join(stack)


### PR DESCRIPTION
## 42883. 가장 큰 수 만들기

### ⏳ 소요 시간
> 6시간

### 💡 풀이 방식
주어진 숫자 문자열 `number`에서 `k`개의 숫자를 제거했을 때 만들 수 있는 가장 큰 수를 구하는 문제이다. 탐욕법(Greedy)으로 접근하며, **리스트 조합, 반복문과 pop, 스택 사용**의 세 가지 방식으로 해결하였다.

### 📝 Pseudo Code
```python
FUNCTION solution(number, k):
    CREATE EMPTY STACK 'stack'
    FOR digit IN number:
        WHILE k > 0 AND stack IS NOT EMPTY AND stack[-1] < digit:
            POP stack[-1]
            DECREMENT k
        APPEND digit TO stack
    
    REMOVE LAST k ELEMENTS FROM stack IF k > 0
    RETURN JOINED STRING OF stack
```

### 🔍 풀이 과정
#### 1️⃣ **완전 탐색 (조합을 활용한 방법, O(nCk))**
- 숫자의 모든 조합을 만들고 최댓값을 찾는 방식
- **시간 복잡도:** `O(nCk)` (조합 생성 과정에서 너무 많은 경우의 수 발생 → 비효율적)
- **결과:** **시간 초과** 발생

#### 2️⃣ **반복문과 pop을 활용한 방법 (O(n*k))**
- `while` 루프를 사용하여 매번 `k`개의 숫자를 제거할 때까지 리스트를 탐색
- 리스트에서 `pop(idx)`를 실행하여 작은 숫자를 제거
- **시간 복잡도:** 리스트 중간 요소 제거 시 O(n) (Python 리스트는 배열 기반이므로 재정렬 발생), **최악의 경우 O(n²)**이 됨
- **결과:** **시간 초과** 발생

#### 3️⃣ **스택을 활용한 탐욕법 (O(n))**
- 스택을 사용하여 숫자를 저장하며, **현재 숫자가 스택의 마지막 숫자보다 크면 pop()을 수행하여 작은 숫자 제거**
- 제거해야 할 숫자 `k`개를 모두 없애면, **남은 숫자를 그대로 반환**
- **시간 복잡도:** `O(n)` (모든 숫자를 한 번씩 탐색하며 스택 연산은 O(1))
- **결과:** **효율적으로 정답 도출**

### ⏱ 시간 복잡도
| 방법 | 시간 복잡도 | 설명 |
|------|------------|--------------------------------|
| **조합 사용 (완전 탐색)** | O(nCk) | 조합을 생성하면서 모든 경우 탐색 (시간 초과) |
| **반복문 + pop** | O(n * k) | pop(idx) 사용으로 리스트 재정렬 발생 (시간 초과) |
| **스택 사용 (탐욕법)** | O(n) | 한 번의 순회만으로 최적의 결과 도출 (최적해) |

### 📊 실제 실행 시간 및 메모리
- 메모리: 12.9 MB
- 시간: 83.54 ms

---

## 42861. 섬 연결하기

### ⏳ 소요 시간
> 2시간

### 💡 풀이 방식
주어진 섬들을 최소 비용으로 연결하는 **최소 신장 트리(MST, Minimum Spanning Tree)** 문제이다. 지난 시간 보경언니의 풀이를 보고 MST를 구하는 알고리즘 중 **프림 알고리즘(Prim's Algorithm)**을 활용하여 해결했다.

### 📝 Pseudo Code
```python
FUNCTION solution(n, costs):
    SORT costs BY cost ASCENDING
    linked = {costs[0][0]}  # 초기 시작점
    answer = 0
    
    WHILE len(linked) != n:
        FOR start, end, cost IN costs:
            IF start IN linked AND end IN linked:
                CONTINUE  # 이미 연결됨 → 건너뜀
            IF start IN linked OR end IN linked:
                linked.update([start, end])  # 연결된 섬 확장
                answer += cost
                BREAK  # 새로운 간선 추가 후 루프 종료
    RETURN answer
```

### 🔍 풀이 과정
#### 1️⃣ **비용 기준으로 정렬**
- `costs`를 비용(cost) 기준으로 오름차순 정렬
- 최소 비용부터 탐색하여 MST를 형성하도록 함

#### 2️⃣ **초기 상태 설정**
- `linked` 집합을 생성하여 연결된 섬을 관리
- `costs[0][0]`을 시작점으로 설정 (처음 한 개의 섬 포함)

#### 3️⃣ **가장 적은 비용의 다리부터 연결**
- `costs` 배열을 순회하며 **하나라도 연결된 섬**이면 다리를 추가
- 두 섬이 모두 `linked`에 있다면 건너뜀
- `linked`가 `n`개의 섬을 모두 포함할 때까지 반복

### ⏱ 시간 복잡도
| 알고리즘 | 시간 복잡도 | 설명 |
|------|------------|--------------------------------|
| **크루스칼 알고리즘** | O(E log E) | 간선을 정렬하고 Union-Find 사용 |
| **프림 알고리즘 (우선순위 큐 사용)** | O(E log V) | 힙을 이용해 간선 선택 |
| **프림 알고리즘 (리스트 사용, 본 코드)** | O(EV) | 간선을 하나씩 탐색하며 MST를 확장 |

### 🚀 고민했던 부분 및 해결 과정
#### ✅ `{[costs[0][0]]}`와 `set([costs[0][0]])`의 차이
| 표현식 | 의미 | 동작 결과 |
|------|------------|--------------------------------|
| `{[costs[0][0]]}` | 리스트는 변경 가능(mutable)하기 때문에 해시할 수 없으므로, 집합의 원소가 될 수 없음 | 리스트를 집합으로 만들려 하므로 TypeError 발생|
| `set([costs[0][0]])`| 리스트를 집합으로 변환 | `{costs[0][0]}` |

#### ✅ `or` 조건 추가하여 MST 확장 유지
- `if start in linked or end in linked:` 조건이 없으면 연결되지 않은 섬들끼리 다리가 추가될 수도 있음
- MST 형성을 위해 반드시 **기존 MST에서 확장**해야 하므로 `or` 조건을 유지

#### ✅ Kruskal이 아닌 Prim 방식인지 검토
- `costs`를 정렬한 후, 최소 비용 간선을 **이미 연결된 섬에서 확장하는 방식**으로 선택
- 크루스칼 알고리즘은 **모든 간선을 정렬 후 하나씩 추가하며 Union-Find를 사용**
- 본 코드는 **이미 연결된 정점에서 최소 비용 간선을 확장**하는 프림 방식

---