### PR TITLE
[week8] 이분탐색

### DIFF
--- a/43238. 입국심사/solution.py
+++ b/43238. 입국심사/solution.py
@@ -1,0 +1,14 @@
+def solution(n, times):
+    start = 1
+    end = max(times) * n
+    
+    while start <= end:
+        mid = (start + end) // 2
+        count = 0
+        for time in times:
+            count += mid // time
+        if count >= n:
+            end = mid - 1
+        else:
+            start = mid + 1
+    return start


### PR DESCRIPTION
## 43238. 입국심사

### ⏳ 소요 시간
> 2시간

### 💡 풀이 방식
주어진 `n`명의 사람들이 `times` 배열에 있는 심사대에서 심사를 받을 때, **모든 사람이 심사를 받는데 걸리는 최소 시간을 구하는 문제**이다.   
이 문제는 이진 탐색 (파라메트릭 서치)을 통해 해결하였다.

### 📝 Pseudo Code
```python
FUNCTION solution(n, times):
    start = 1
    end = max(times) * n
    
    WHILE start <= end:
        mid = (start + end) // 2
        count = 0
        FOR time IN times:
            count += mid // time
        
        IF count >= n:
            end = mid - 1
        ELSE:
            start = mid + 1
            
    RETURN start
```

### 🔍 풀이 과정
#### 1️⃣ **이진 탐색을 이용한 시간 범위 설정**
- `start`는 **가장 빠르게 심사가 끝나는 시간(1분)**,  
  `end`는 **가장 느리게 심사가 끝나는 시간 `(max(times) * n)`**으로 설정.  
- **이진 탐색**을 통해 가능한 시간 중 최솟값을 탐색.

#### 2️⃣ **중간 시간(`mid`) 동안 처리 가능한 사람 수 계산**
- `mid` 시간 동안 `times`의 각 심사관이 처리할 수 있는 사람 수를 합산.
- `count`가 `n` 이상인 경우 → `end`를 줄여 더 짧은 시간에서 가능한지 탐색.  
- `count`가 `n` 미만인 경우 → `start`를 늘려 더 긴 시간 탐색.

#### 3️⃣ **최솟값 갱신**
- 가능한 시간 중 **가장 작은 시간**을 찾기 위해 `start`를 반환.


### 🤔 고민했던 내용
1. **단순 분배 vs. 최소공배수 사용 여부**
   - 처음에는 `times`의 최소공배수를 이용해 사람을 분배하는 방식으로 접근하려 했으나,  
     `n`과 `times`의 크기가 커질수록 비효율적이라는 문제를 발견.  
   - 이진 탐색을 이용해 시간을 이분화하여 최적의 해를 찾는 방식이 더 효율적이라는 결론.

2. **count를 초기화하는 위치**
   - `count`가 `while` 바깥에서 초기화될 경우 누적되어 잘못된 결과가 나옴.  
   - 매번 `while` 루프 안에서 초기화하도록 변경하여 해결.

3. **최솟값 반환 시 `start`와 `end`의 역할**
   - 최종적으로 `start`가 가능한 최소 시간을 가리키기 때문에 `start`를 반환.  
   - `end`가 `mid - 1`로 줄어들기 때문에 `end`를 반환하면 오답.


### ⏱ 시간 복잡도
| 단계                      | 시간 복잡도    | 설명                                                      |
|--------------------------|----------------|-----------------------------------------------------------|
| 이진 탐색                 | O(log(max * n))| 가능한 시간 범위를 이분 탐색으로 줄여나감                  |
| 사람 수 계산 (`for` 루프) | O(m)           | m은 심사관 수, 각 `mid`마다 모든 심사관 탐색               |
| **총 시간 복잡도**         | **O(m * log(max * n))** | 심사관 수가 많아도 효율적으로 탐색 가능                    |


### 📊 실제 실행 시간 및 메모리
- **메모리:** 14.3 MB
- **시간:** 595.36 ms

