### PR TITLE
16928. 뱀과 사다리 게임

### DIFF
--- a/16928. 뱀과 사다리 게임/solution.py
+++ b/16928. 뱀과 사다리 게임/solution.py
@@ -1,0 +1,44 @@
+from collections import deque, defaultdict
+
+def bfs(board):
+    queue = deque([1])
+    visited = [False] * 101
+    visited[1] = True
+    dist = [0] * 101
+
+    while queue:
+        curr = queue.popleft()
+
+        for dice in range(1, 7):
+            next = curr + dice
+            if next > 100:
+                continue
+
+            jump = board[next]
+            if not visited[jump]:
+                visited[jump] = True
+                dist[jump] = dist[curr] + 1
+                queue.append(jump)
+        
+    return dist[100]
+
+
+def main():
+    N, M = map(int, input().split())
+    board = [i for i in range(101)]
+
+    for _ in range(N):
+        k, v = map(int, input().split())
+        board[k] = v
+    
+    for _ in range(M):
+        k, v = map(int, input().split())
+        board[k] = v
+    
+    dist = bfs(board)
+
+    print(dist)
+    
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 16928. 뱀과 사다리 게임

### ⏳ 소요 시간
> 약 3시간

### 💡 풀이 방식
- 주사위를 굴려 1번 칸부터 100번 칸까지 최소 횟수로 도달하는 경로를 **BFS**를 통해 탐색
- `board[i] = jump 위치` 형태로 사다리/뱀 정보를 저장해 특정 칸에 도착했을 때 즉시 점프 처리
- BFS 진행 시, 각 칸에서 주사위 1~6까지 가능한 이동을 시도하고 도착한 칸이 사다리/뱀이면 해당 칸으로 점프하여 큐에 추가

### 🧠 주요 고민 지점
- 초기에는 사다리와 각 칸에서 점프 가능한 칸을 graph에 미리 넣고 뱀은 무시하는 방식으로 설계했으나, **뱀을 무시하면 경로가 왜곡되어 최소 이동 수 계산이 틀어지는 문제** 발생
  - 이를 해결하기 위해 사다리와 뱀 모두를 `board[i] = jump된 칸`으로 매핑하여 처리

### 📝 Pseudo Code
```
FUNCTION bfs(board):
INIT queue with 1
INIT visited[101] = False, visited[1] = True
INIT dist[101] = 0

WHILE queue NOT empty:
    curr ← queue.popleft()
    FOR dice IN 1..6:
        next = curr + dice
        IF next > 100: CONTINUE
        jump = board[next]
        IF NOT visited[jump]:
            visited[jump] = True
            dist[jump] = dist[curr] + 1
            queue.append(jump)
RETURN dist[100]

FUNCTION main():
board ← [i for i in range(101)]
READ 사다리 정보 → board[x] = y
READ 뱀 정보 → board[x] = y
PRINT bfs(board)
```
### ⏱ 시간 복잡도
- `BFS`: 최대 100개의 칸을 한 번씩 방문 → **$O(100) = O(1)$** (상수)
- 입력 개수도 최대 30개 (사다리+뱀) → **입력 처리도 $O(1)$**  
- **총 시간 복잡도: $O(1)$** (상수 시간)

### 📊 실제 실행 시간 및 메모리
- 메모리: 34952 KB
- 시간: 64 ms