### PR TITLE
2169. 로봇 조종하기

### DIFF
--- a/2169. 로봇 조종하기/solution.py
+++ b/2169. 로봇 조종하기/solution.py
@@ -1,0 +1,27 @@
+N, M = map(int, input().split())
+mars = []
+
+for _ in range(N):
+    mars.append(list(map(int, input().split())))
+
+dp = [[0] * M for _ in range(N)]
+dp[0][0] = mars[0][0]
+for col in range(1, M):
+    dp[0][col] = dp[0][col - 1] + mars[0][col]
+
+for row in range(1, N):
+    temp_left = [0] * M
+    temp_right = [0] * M
+
+    temp_left[0] = dp[row - 1][0] + mars[row][0]
+    for col in range(1, M):
+        temp_left[col] = max(temp_left[col - 1], dp[row - 1][col]) + mars[row][col]
+
+    temp_right[M - 1] = dp[row - 1][M - 1] + mars[row][M - 1]
+    for col in range(M - 2, -1, -1):
+        temp_right[col] = max(temp_right[col + 1], dp[row - 1][col]) + mars[row][col]
+
+    for col in range(M):
+        dp[row][col] = max(temp_left[col], temp_right[col])
+    
+print(dp[N - 1][M - 1])


### PR DESCRIPTION
## 2169. 로봇 조종하기

### ⏳ 소요 시간
> 약 2시간  
> (2-way 스캔 로직과 인덱스 혼동, `temp` 버퍼와 `dp` 관계를 정리하는 데 시간이 걸림)

### 💡 풀이 방식
- 화성 지형을 `N×M` 격자로 단순화하고, 각 칸의 탐사 가치를 최대화하도록 경로를 선택함
- 로봇은 오른쪽, 왼쪽, 아래쪽으로만 이동 가능하며, 한 번 방문한 칸은 다시 방문하지 않음
- **DP + 2-way 스캔**:
  - 한 줄씩 내려가면서 `왼쪽 → 오른쪽`과 `오른쪽 → 왼쪽` 두 방향으로 각각 최대 값을 따로 계산
  - `temp_left`, `temp_right` 임시 버퍼를 사용해 **한 줄 안에서의 가로 이동 경로**를 별도로 관리
  - 최종적으로 두 방향 중 더 큰 값을 `dp[y][x]`로 갱신

### 🧠 주요 고민 지점
- 초기에는 단순히 `dp[y][x] = max(dp[y-1][x], dp[y][x-1], dp[y][x + 1]) + value` 형태로 풀려 했으나, **왼쪽↔오른쪽 양방향 이동 가능성**을 반영하지 못함
- `temp_left`와 `temp_right`에서 **왜 위쪽 값(dp)과 옆 칸 값을 동시에 비교해야 하는지** 개념이 혼동됨
- **첫 줄은 위쪽 경로가 없으므로 단방향으로만 누적**, 그 이후 줄부터 2-way 스캔 필요하다는 점을 코드에 반영하면서 흐름을 확실히 잡음

### 📝 Pseudo Code

```INIT dp[N][M]
dp[0][0] ← grid[0][0]

FOR col = 1 to M-1:
dp[0][col] ← dp[0][col-1] + grid[0][col]

FOR row = 1 to N-1:
temp_left[0] ← dp[row-1][0] + grid[row][0]
FOR col = 1 to M-1:
temp_left[col] ← max(temp_left[col-1], dp[row-1][col]) + grid[row][col]

temp_right[M-1] ← dp[row-1][M-1] + grid[row][M-1]
FOR col = M-2 downto 0:
    temp_right[col] ← max(temp_right[col+1], dp[row-1][col]) + grid[row][col]

FOR col = 0 to M-1:
    dp[row][col] ← max(temp_left[col], temp_right[col])

PRINT dp[N-1][M-1]
```

### ⏱ 시간 복잡도
- 한 줄 처리에 $O(M)$, 전체 $N$줄에 대해 $O(NM)$  

### 📊 실제 실행 시간 및 메모리
- 메모리: 94984 KB
- 시간: 1184 ms